### PR TITLE
Support Filtering

### DIFF
--- a/spec/features/filter_spec.cr
+++ b/spec/features/filter_spec.cr
@@ -1,0 +1,30 @@
+require "../spec_helper"
+
+module TeeplateFileTreeTemplateFeature
+  extend HaveFiles::Spec::Dsl
+
+  class Template < Teeplate::FileTree
+    directory "#{__DIR__}/../../test/file_tree_template/template"
+
+    @file : String
+    @class : String
+    @author : String
+    @year : Int32
+
+    def initialize(@file, @class, @author, @year)
+    end
+
+    def filter(entries)
+      entries.reject{ |entry| entry.path.includes? "version.cr" }
+    end
+  end
+
+  it name do
+    HaveFiles.tmpdir do |tmp|
+      Template.new("teeplate", "Teeplate", "mosop", 2016).render(tmp)
+      expected_file = "#{__DIR__}/../../test/file_tree_template/expected/src/teeplate/version.cr"
+      tmp.should_not have_files expected_file
+    end
+  end
+end
+

--- a/spec/features/filter_spec.cr
+++ b/spec/features/filter_spec.cr
@@ -12,11 +12,11 @@ module TeeplateFileTreeTemplateFeature
     @year : Int32
 
     def initialize(@file, @class, @author, @year)
-      @include_version = false
+      @exclude_version = true
     end
 
     def filter(entries)
-      entries.reject{ |entry| entry.path.includes?("version.cr") && !@include_version }
+      entries.reject{ |entry| entry.path.includes?("version.cr") && @exclude_version }
     end
   end
 

--- a/spec/features/filter_spec.cr
+++ b/spec/features/filter_spec.cr
@@ -19,7 +19,7 @@ module TeeplateFileTreeTemplateFeature
     end
   end
 
-  it name do
+  it "filters templates" do
     HaveFiles.tmpdir do |tmp|
       Template.new("teeplate", "Teeplate", "mosop", 2016).render(tmp)
       expected_file = "#{__DIR__}/../../test/file_tree_template/expected/src/teeplate/version.cr"

--- a/spec/features/filter_spec.cr
+++ b/spec/features/filter_spec.cr
@@ -1,9 +1,9 @@
 require "../spec_helper"
 
-module TeeplateFileTreeTemplateFeature
+module FilterFeature
   extend HaveFiles::Spec::Dsl
 
-  class Template < Teeplate::FileTree
+  class FilterTemplate < Teeplate::FileTree
     directory "#{__DIR__}/../../test/file_tree_template/template"
 
     @file : String
@@ -12,17 +12,17 @@ module TeeplateFileTreeTemplateFeature
     @year : Int32
 
     def initialize(@file, @class, @author, @year)
-      @exclude_version = true
+      @skip_version = true
     end
 
     def filter(entries)
-      entries.reject{ |entry| entry.path.includes?("version.cr") && @exclude_version }
+      entries.reject{ |entry| entry.path.includes?("version.cr") && @skip_version }
     end
   end
 
-  it "filters templates" do
+  it "filters templates based on options" do
     HaveFiles.tmpdir do |tmp|
-      Template.new("teeplate", "Teeplate", "mosop", 2016).render(tmp)
+      FilterTemplate.new("teeplate", "Teeplate", "mosop", 2016).render(tmp)
       expected_file = "#{__DIR__}/../../test/file_tree_template/expected/src/teeplate/version.cr"
       tmp.should_not have_files expected_file
     end

--- a/spec/features/filter_spec.cr
+++ b/spec/features/filter_spec.cr
@@ -12,10 +12,11 @@ module TeeplateFileTreeTemplateFeature
     @year : Int32
 
     def initialize(@file, @class, @author, @year)
+      @include_version = false
     end
 
     def filter(entries)
-      entries.reject{ |entry| entry.path.includes? "version.cr" }
+      entries.reject{ |entry| entry.path.includes?("version.cr") && !@include_version }
     end
   end
 

--- a/src/lib/file_tree.cr
+++ b/src/lib/file_tree.cr
@@ -23,9 +23,14 @@ module Teeplate
     # For more information about the arguments, see `Renderer`.
     def render(out_dir, force : Bool = false, interactive : Bool = false, interact : Bool = false, list : Bool = false, color : Bool = false, per_entry : Bool = false, quit : Bool = true)
       renderer = Renderer.new(out_dir, force: force, interact: interactive || interact, list: list, color: color, per_entry: per_entry, quit: quit)
-      renderer << file_entries
+      renderer << filter(file_entries)
       renderer.render
       renderer
+    end
+
+    # Override to filter files rendered.
+    def filter(entries)
+      entries
     end
 
     # :nodoc:


### PR DESCRIPTION
This change adds a hook to allow filtering of files before rendering.  I use this to be able to support multiple templating languages in kemalyst.  I can filter out the `ecr` or `slang` templates based on a flag passed in the generator.