### PR TITLE
Fix heredoc usage when embedding blob

### DIFF
--- a/src/lib/file_tree/macros/directory.cr
+++ b/src/lib/file_tree/macros/directory.cr
@@ -39,13 +39,16 @@ def pack_blob(sb, abs, rel)
   io = IO::Memory.new
   File.open(abs) { |f| IO.copy(f, io) }
   if io.size > 0
-    STDOUT << "#{io.size}_u64, <<-EOS\n"
-    Base64.encode io, STDOUT
-    STDOUT << "EOS\n"
+    STDOUT << "#{io.size}_u64, <<-EOS"
   else
     STDOUT << "0_u64, \"\""
   end
-  STDOUT << ", File::Permissions.from_value(#{File.info(abs).permissions.value}))"
+  STDOUT << ", File::Permissions.from_value(#{File.info(abs).permissions.value}))\n"
+
+  if io.size > 0
+    Base64.encode io, STDOUT
+    STDOUT << "EOS\n"
+  end
 end
 
 STDOUT << "def ____collect_files(____files)"


### PR DESCRIPTION
Since https://github.com/crystal-lang/crystal/pull/5578 embedding a non-empty blob file expands to invalid code.

@mosop not sure if the blob embedded is tested somewhere in the code.

cc: @paulcsmith, I notice this while checking luck_cli and how files are embedded. Somehow in my end  I got:

```
# Installing teeplate (0.6.1)
# Error in src/lucky.cr:2: while requiring "./lucky_cli"
# 
# require "./lucky_cli"
# ^
# 
# in src/lucky_cli.cr:2: while requiring "./lucky_cli/**"
# 
# require "./lucky_cli/**"
# ^
# 
# in src/lucky_cli/base_authentication_src_template.cr:2: macro didn't expand to a valid program, it expanded to:
# 
# ================================================================================
# --------------------------------------------------------------------------------
#    1.       def ____collect_files(____files)
#    2. ____files << ::Teeplate::Base64Data.new("db/migrations/00000000000001_create_users.cr", 242_u64, <<-EOS
#    3. Y2xhc3MgQ3JlYXRlVXNlcnM6OlYwMDAwMDAwMDAwMDAwMSA8IEx1Y2t5UmVj
#    4. b3JkOjpNaWdyYXRvcjo6TWlncmF0aW9uOjpWMQogIGRlZiBtaWdyYXRlCiAg
#    5. ICBjcmVhdGUgOnVzZXJzIGRvCiAgICAgIGFkZCBlbWFpbCA6IFN0cmluZywg
#    6. dW5pcXVlOiB0cnVlCiAgICAgIGFkZCBlbmNyeXB0ZWRfcGFzc3dvcmQgOiBT
#    7. dHJpbmcKICAgIGVuZAogIGVuZAoKICBkZWYgcm9sbGJhY2sKICAgIGRyb3Ag
#    8. OnVzZXJzCiAgZW5kCmVuZAo=
#    9. EOS
#   10. , File::Permissions.from_value(420))
```