### PR TITLE
Annotate return types and fix values

### DIFF
--- a/src/lib/base64_data.cr
+++ b/src/lib/base64_data.cr
@@ -13,12 +13,12 @@ module Teeplate
       @forces = force
     end
 
-    def size?
+    def size? : UInt64
       @size
     end
 
-    def perm?
-      @perm
+    def perm? : UInt16
+      @perm.value.to_u16
     end
 
     def write_to(io : IO)

--- a/src/lib/file_data.cr
+++ b/src/lib/file_data.cr
@@ -14,12 +14,12 @@ module Teeplate
       @forces = force
     end
 
-    def size?
+    def size? : UInt64
       @size
     end
 
-    def perm?
-      @perm
+    def perm? : UInt16
+      @perm.value.to_u16
     end
 
     def write_to(io : IO)

--- a/src/lib/string_data.cr
+++ b/src/lib/string_data.cr
@@ -12,12 +12,12 @@ module Teeplate
       @forces = force
     end
 
-    def size?
-      @string.size
+    def size? : UInt64
+      @string.size.to_u64
     end
 
-    def perm?
-      @perm
+    def perm? : UInt16
+      @perm.value.to_u16
     end
 
     def write_to(io : IO)


### PR DESCRIPTION
Note: it would be better to return ::File::Permission since there are already available for a couple of versions. That will avoid also the UInt16 vs Int16 discrepancies between the enum definition and the perm? methods.