### PR TITLE
Use crystal-community/future.cr

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -6,6 +6,11 @@ authors:
 
 crystal: 0.26.1
 
+dependencies:
+  future:
+    github: crystal-community/future.cr
+    version: ~> 0.1.0
+
 development_dependencies:
   have_files:
     github: mosop/have_files

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "future"
 require "have_files/spec/dsl"
 require "../src/teeplate"
 

--- a/src/lib/rendering_entry.cr
+++ b/src/lib/rendering_entry.cr
@@ -1,3 +1,5 @@
+require "future"
+
 module Teeplate
   class RenderingEntry
     # :nodoc:


### PR DESCRIPTION
These are the changes need to upgrade to Crystal 0.35

The future top-level method is deprecated in 0.35 and moved out to shard.

This is a backward compatible change.