### PR TITLE
Add support for multiple directories

### DIFF
--- a/spec/features/file_tree_template_spec.cr
+++ b/spec/features/file_tree_template_spec.cr
@@ -4,7 +4,7 @@ module TeeplateFileTreeTemplateFeature
   extend HaveFiles::Spec::Dsl
 
   class Template < Teeplate::FileTree
-    directory "#{__DIR__}/../../test/file_tree_template/template"
+    directories ["#{__DIR__}/../../test/file_tree_template/template"]
 
     @file : String
     @class : String

--- a/src/lib/file_tree.cr
+++ b/src/lib/file_tree.cr
@@ -8,6 +8,12 @@ module Teeplate
       {{ run(__DIR__ + "/file_tree/macros/directory", dir.id) }}
     end
 
+    macro directories(list_of_dirs)
+      {% for dir in list_of_dirs %}
+        {{ run(__DIR__ + "/file_tree/macros/directory", dir.id) }}
+      {% end %}
+    end
+
     @file_entries : Array(AsDataEntry)?
     # Returns collected file entries.
     def file_entries : Array(AsDataEntry)


### PR DESCRIPTION
I added a single method & converted a spec to use it. CLI's, such as Amber's, have a lot of redundant files. My thought is, if we can have support for multiple directories, we can set base templates and then pass in a others as modifiers. 

Currently, the spec only uses 1 directory. If others are interested in this feature, i can write a couple specs to test for multiple directories. Just want to get everyone's idea on this feature.